### PR TITLE
Define reusable constants for PDA and Anchor discriminator

### DIFF
--- a/week-2/escrow/programs/escrow/src/constants.rs
+++ b/week-2/escrow/programs/escrow/src/constants.rs
@@ -1,0 +1,5 @@
+use anchor_lang::prelude::*;
+
+#[constant]
+pub const SEED: &str = "escrow";
+pub const ANCHOR_DISCREMINATOR: usize = 8;

--- a/week-2/escrow/programs/escrow/src/instructions/make.rs
+++ b/week-2/escrow/programs/escrow/src/instructions/make.rs
@@ -47,7 +47,7 @@ pub struct Make<'info> {
         payer = maker,
         seeds = [SEED.as_bytes(), maker.key().as_ref(), seed.to_le_bytes().as_ref()],
         bump,
-        space = 8 + Escrow::INIT_SPACE,
+        space = ANCHOR_DISCREMINATOR + Escrow::INIT_SPACE,
     )]
     pub escrow: Account<'info, Escrow>,
 

--- a/week-2/escrow/programs/escrow/src/instructions/make.rs
+++ b/week-2/escrow/programs/escrow/src/instructions/make.rs
@@ -4,6 +4,7 @@ use anchor_spl::{
     token_interface::{ Mint, TokenAccount, TransferChecked, TokenInterface, transfer_checked}
 };
 
+use crate::constants::*;
 use crate::states::Escrow;
 
 #[derive(Accounts)]
@@ -44,7 +45,7 @@ pub struct Make<'info> {
     #[account(
         init,
         payer = maker,
-        seeds = [b"escrow", maker.key().as_ref(), seed.to_le_bytes().as_ref()],
+        seeds = [SEED.as_bytes(), maker.key().as_ref(), seed.to_le_bytes().as_ref()],
         bump,
         space = 8 + Escrow::INIT_SPACE,
     )]

--- a/week-2/escrow/programs/escrow/src/instructions/refund.rs
+++ b/week-2/escrow/programs/escrow/src/instructions/refund.rs
@@ -7,6 +7,7 @@ use anchor_spl::{
     },
 };
 
+use crate::constants::*;
 use crate::states::Escrow;
 
 #[derive(Accounts)]
@@ -42,7 +43,7 @@ pub struct Refund<'info> {
         close = maker,
         has_one = mint_a,
         has_one = maker,
-        seeds = [b"escrow", maker.key().as_ref(), escrow.seed.to_le_bytes().as_ref()],
+        seeds = [SEED.as_bytes(), maker.key().as_ref(), escrow.seed.to_le_bytes().as_ref()],
         bump = escrow.bump,
     )]
     pub escrow: Account<'info, Escrow>,
@@ -70,7 +71,7 @@ impl<'info> Refund<'info> {
     pub fn refund_and_close_vault(&mut self) -> Result<()> {
         // Create PDA signer seeds for vault authority
         let signer_seeds: &[&[&[u8]]; 1] = &[&[
-            b"escrow", 
+            SEED.as_bytes(), 
             self.maker.key.as_ref(), 
             &self.escrow.seed.to_le_bytes()[..],
             &[self.escrow.bump]

--- a/week-2/escrow/programs/escrow/src/instructions/take.rs
+++ b/week-2/escrow/programs/escrow/src/instructions/take.rs
@@ -7,6 +7,7 @@ use anchor_spl::{
     },
 };
 
+use crate::constants::*;
 use crate::states::Escrow;
 
 /// Instruction for completing an escrow trade.
@@ -83,7 +84,7 @@ pub struct Take<'info> {
         has_one = mint_a,
         has_one = maker,
         has_one = mint_b,
-        seeds = [b"escrow", maker.key().as_ref(), escrow.seed.to_le_bytes().as_ref()],
+        seeds = [SEED.as_bytes(), maker.key().as_ref(), escrow.seed.to_le_bytes().as_ref()],
         bump = escrow.bump,
     )]
     pub escrow: Account<'info, Escrow>,
@@ -134,7 +135,7 @@ impl<'info> Take<'info> {
     pub fn transfer_and_close_vault(&mut self) -> Result<()> {
         // Create PDA signer seeds for vault authority
         let signer_seeds: &[&[&[u8]]; 1] = &[&[
-            b"escrow",
+            SEED.as_bytes(),
             self.maker.key.as_ref(),
             &self.escrow.seed.to_le_bytes()[..],
             &[self.escrow.bump],

--- a/week-2/escrow/programs/escrow/src/lib.rs
+++ b/week-2/escrow/programs/escrow/src/lib.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 
 declare_id!("ABagojQQU4h1roF1U2ZC2vqvMVrWcBx2gCq1Gy95KEvJ");
 
+pub mod constants;
 pub mod instructions;
 pub mod states;
 


### PR DESCRIPTION
### This PR introduces two new constants to improve code readability and avoid repetition:
- SEED: Used for PDA derivation to ensure consistent seed usage across the program.
- ANCHOR_DISCRIMINATOR: Added to standardize the 8-byte discriminator used by Anchor for instruction serialization.

**Changes Made**
- Defined SEED and ANCHOR_DISCRIMINATOR in the constants module.
- Replaced hardcoded values with these constants in relevant files.

These changes aim to make the codebase cleaner and easier to maintain.

**Build Successful** — all changes compiled without errors.
<img width="1259" height="389" alt="Screenshot 2025-07-18 at 3 02 19 PM" src="https://github.com/user-attachments/assets/2b2f7d32-300a-4c3c-8202-60b3145d0241" />

**Deploy Successful**
<img width="1182" height="221" alt="Screenshot 2025-08-01 at 12 17 28 AM" src="https://github.com/user-attachments/assets/610aac9f-e220-4be8-ba94-e9d674b18a5c" />

**Tests Successful**
<img width="1400" height="498" alt="Screenshot 2025-08-01 at 12 17 58 AM" src="https://github.com/user-attachments/assets/156a214c-5898-4877-bbf5-a3e346358446" />