### PR TITLE
[Critical] Usage of unscaled decimal precision in AMM's deposit/withdraw functions leads to incorrect pool accounting

### DIFF
--- a/week-2/amm/programs/amm/src/instructions/deposit.rs
+++ b/week-2/amm/programs/amm/src/instructions/deposit.rs
@@ -148,7 +148,7 @@ impl<'info> Deposit<'info> {
                     self.vault_y.amount, 
                     self.mint_lp.supply, 
                     amount, 
-                    6  // Precision for calculations
+                    1_000_000 // Scaled precision for calculations
                 ).unwrap();
                 (amounts.x, amounts.y)
             }

--- a/week-2/amm/programs/amm/src/instructions/withdraw.rs
+++ b/week-2/amm/programs/amm/src/instructions/withdraw.rs
@@ -147,7 +147,7 @@ impl<'info> Withdraw<'info> {
                     self.vault_y.amount,   // Current vault Y balance
                     self.mint_lp.supply,   // Current LP token supply
                     amount,                // LP tokens being burned
-                    6,                     // Precision for calculations
+                    1_000_000,                     // Scaled precision for calculations
                 )
                 .unwrap();
                 (amounts.x, amounts.y)


### PR DESCRIPTION
`ConstantProduct::{xy_deposit_amounts_from_l(...,precision: u32) )` && `xy_withdraw_amounts_from_l(..., precision: u32)}` expect precision parameter to be fully scaled , not the no of decimal place count. Nowhere in their implementation, the given decimal number is powered with 10, instead both take the precision parameter as it is and calculate directly with it.

In contrast, we are incorrectly passing 6 as precision to these helper functions in our amm's deposit and withdraw functions.

Maybe the  assumption for this incorrect behaviour was that these functions scale the given decimal number automatically with the power of 10, just like ConstantProduct::Init() does but that is not the case.

Maybe we should pass fully scaled decimal precision to these functions in amm's deposit/withdraw.

Would love to get feedback from you , kindly validate whether this fix is realistic or not

Thanks.